### PR TITLE
Update celeryconfig.py.example to use BROKER_URL and remove deprecated c...

### DIFF
--- a/celeryconfig.py.example
+++ b/celeryconfig.py.example
@@ -2,12 +2,8 @@
 #
 # Rename this file to celeryconfig.py
 # Command for test:
-# celeryd --loglevel=INFO
-BROKER_HOST = 'localhost'
-BROKER_PORT = 5672
-BROKER_USER = 'myuser'
-BROKER_PASSWORD = 'mypassword'
-BROKER_VHOST = 'myvhost'
+# celery worker --loglevel=INFO
+BROKER_URL = 'amqp://myuser:mypassword@localhost:5672//'
 CELERY_IMPORTS = ("test_tasks", )
 CELERY_RESULT_BACKEND = "amqp"
 CELERY_AMQP_TASK_RESULT_EXPIRES = 1000

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,7 @@ How to run these tests.
 1. Install celery, then copy ``celeryconfig.py.example`` to ``celeryconfig.py``
 and tune the configuration file. Follow celery "getting started" guide:
 http://docs.celeryproject.org/en/latest/getting-started/index.html
-2. Launch celeryd as ``celeryd --loglevel=INFO``.
+2. Launch the celery worker with ``celery worker --loglevel=INFO``.
 Make sure that tasks "test_tasks.mkdir" and "test_tasks.MkdirTask" are found.
 3. Run tests with ``nosetests`` command.
 


### PR DESCRIPTION
...onfig variables. Update test documentation to substitute references to the deprecated 'celeryd' with 'celery worker'.
